### PR TITLE
Use suffix from bsconfig in jsFilePath

### DIFF
--- a/src/helpers/jsFilePath.js
+++ b/src/helpers/jsFilePath.js
@@ -1,11 +1,11 @@
 import * as path from 'path';
 
-const jsFilePath = (buildDir, moduleDir, resourcePath, inSource) => {
+const jsFilePath = (buildDir, moduleDir, resourcePath, inSource, suffix) => {
   const outputDir = 'lib';
   const fileNameRegex = /\.(ml|re)$/;
 
   const mlFileName = resourcePath.replace(buildDir, '');
-  const jsFileName = mlFileName.replace(fileNameRegex, '.js');
+  const jsFileName = mlFileName.replace(fileNameRegex, suffix);
 
   if (inSource) {
     return path.join(buildDir, jsFileName);


### PR DESCRIPTION
The plugin was reading the correct suffix and passing it to
`jsFilePath`, but then it was never used and was hard coded to `.js`.