### PR TITLE
Handle case where `package-specs` in bsConfig is an object

### DIFF
--- a/src/helpers/getBsConfigModuleOptions.js
+++ b/src/helpers/getBsConfigModuleOptions.js
@@ -1,4 +1,5 @@
 import { readBsConfigSync } from 'read-bsconfig';
+import getPackageSpecs from './getPackageSpecs';
 
 const getBsConfigModuleOptions = buildDir => {
   const bsconfig = readBsConfigSync(buildDir);
@@ -9,21 +10,7 @@ const getBsConfigModuleOptions = buildDir => {
 
   const bsSuffix = bsconfig.suffix;
   const suffix = typeof bsSuffix === 'string' ? bsSuffix : '.js';
-
-  if (!bsconfig['package-specs'] || !bsconfig['package-specs'].length) {
-    const options = {
-      moduleDir: 'es6',
-      inSource: false,
-      suffix,
-    };
-    return options;
-  }
-
-  const moduleSpec = bsconfig['package-specs'][0];
-  const moduleDir =
-    typeof moduleSpec === 'string' ? moduleSpec : moduleSpec.module;
-  const inSource =
-    typeof moduleSpec === 'string' ? false : moduleSpec['in-source'];
+  const { moduleDir, inSource } = getPackageSpecs(bsconfig['package-specs']);
 
   const options = { moduleDir, inSource, suffix };
   return options;

--- a/src/helpers/getPackageSpecs.js
+++ b/src/helpers/getPackageSpecs.js
@@ -1,0 +1,26 @@
+const getPackageSpecs = packageSpecs => {
+  const defaults = {
+    moduleDir: 'es6',
+    inSource: false,
+  };
+
+  if (!packageSpecs) {
+    return defaults;
+  }
+
+  if (Array.isArray(packageSpecs) && packageSpecs.length === 0) {
+    return defaults;
+  }
+
+  const moduleSpec = Array.isArray(packageSpecs)
+    ? packageSpecs[0]
+    : packageSpecs;
+  const moduleDir =
+    typeof moduleSpec === 'string' ? moduleSpec : moduleSpec.module;
+  const inSource =
+    typeof moduleSpec === 'string' ? false : moduleSpec['in-source'];
+
+  return { moduleDir, inSource };
+};
+
+export default getPackageSpecs;


### PR DESCRIPTION
This now properly handles when package-specs is defined as an object. I
also moved the code to a separate helper function to handle all the
different cases.